### PR TITLE
Disable publishing of sha256/sha512 checksums

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,5 @@ android.library.defaults.buildfeatures.androidresources=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.import.enableKgpDependencyResolution=true
 
+systemProp.org.gradle.internal.publish.checksums.insecure=true
 systemProp.org.gradle.s3.endpoint=https://storage.yandexcloud.net


### PR DESCRIPTION
To reduce the number of files transferred to S3.